### PR TITLE
fix: add GitHub rate limit HTML page detection

### DIFF
--- a/multi_swe_bench/collect/build_dataset.py
+++ b/multi_swe_bench/collect/build_dataset.py
@@ -69,6 +69,12 @@ def extract_patches(pull: dict, token: str) -> tuple[str, str]:
     patch = requests.get(pull["diff_url"], headers=headers).text
     test_patch = ""
     fix_patch = ""
+    # print(f"patch: {patch}")
+    # Detect GitHub rate limit HTML page
+    if "exceeded a secondary rate limit" in patch or "Access to this site has been restricted" in patch:
+        print("GitHub API rate limit exceeded or Network error.")
+        raise Exception("GitHub API rate limit exceeded. Please wait before making additional requests, or check your network connection.")
+  
     for hunk in PatchSet(patch):
         if any(
             test_word in hunk.path for test_word in ["test", "tests", "e2e", "testing"]


### PR DESCRIPTION
 
Found an undetected error during data collection (Step 5:build_dataset) that caused the process to miss a lot of PR data. Here’s what happened: 
 
1. GitHub’s rate limit targets the **IP address**, not the GitHub token.  
2. Each IP can only make a few requests per minute —exceeding this triggers the error.  

[Rate limits for the REST API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28)

