### PR TITLE
Clean repos during check commit phase

### DIFF
--- a/multi_swe_bench/harness/run_evaluation.py
+++ b/multi_swe_bench/harness/run_evaluation.py
@@ -531,6 +531,11 @@ class CliArgs:
                 git_util.clone_repository(self.repo_dir / repo.org, repo.org, repo.repo)
 
             is_clean, error_msg = git_util.is_clean(repo_dir)
+            #if it is not clean, try to clean it
+            if not is_clean:
+                is_clean, error_msg = True, ""
+                git_util.clean(repo_dir)
+            #check if it is clean again
             if not is_clean:
                 self.logger.error(error_msg)
                 error_happened = True

--- a/multi_swe_bench/utils/git_util.py
+++ b/multi_swe_bench/utils/git_util.py
@@ -66,3 +66,7 @@ def get_all_commit_hashes(repo_path: Path, logger: logging.Logger) -> set[str]:
     except GitError as e:
         logger.error(f"Git error occurred: {e}")
         return set()
+
+def clean(repo_dir):
+    subprocess.run(["git", "reset", "--hard"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "clean", "-fd"], cwd=repo_dir, check=True)


### PR DESCRIPTION
[Evaluation] Clean repos instead of raising error during checking commit phase.

Evaluation stage was giving error when finding dirty repositories.
Added a clean(repo) method in git_utils.
Modified run_evaluation to attempt to clean the repository before giving error.
After cleaning, it checks if it is clean again, if so it raises error.