### PR TITLE
Remove Future Git History from Dockerfiles

### DIFF
--- a/multi_swe_bench/harness/build_dataset.py
+++ b/multi_swe_bench/harness/build_dataset.py
@@ -48,6 +48,28 @@ from multi_swe_bench.utils.fs_utils import copy_source_code
 from multi_swe_bench.utils.logger import get_non_propagate_logger, setup_logger
 
 
+def _strip_future_history_run(repo_dir: str, base_sha: str) -> str:
+    """Dockerfile RUN block that scopes a cloned repo to base_sha's ancestors.
+
+    Detaches HEAD at `base_sha`, deletes every ref under `refs/heads/`,
+    `refs/remotes/`, `refs/tags/`, drops the origin URL, expires reflogs,
+    and runs `git gc --prune=now`. 
+    HEAD's ancestor chain is preserved, so `git log`, `git blame`, and 
+    `git show <past-sha>` continue to work.
+    """
+    return (
+        "\n"
+        "# Strip future git history so agents can't read the reference fix.\n"
+        f"RUN cd {repo_dir} && \\\n"
+        f"    git checkout {base_sha} && \\\n"
+        "    git remote remove origin && \\\n"
+        "    git for-each-ref --format='delete %(refname)' refs/heads refs/remotes refs/tags | git update-ref --stdin && \\\n"
+        "    rm -f .git/FETCH_HEAD .git/ORIG_HEAD && \\\n"
+        "    git reflog expire --expire=now --all && \\\n"
+        "    git gc --prune=now\n"
+    )
+
+
 def get_parser() -> ArgumentParser:
     parser = ArgumentParser(
         description="A command-line tool for processing build dataset."
@@ -551,8 +573,15 @@ class CliArgs:
 
         dockerfile_path = image_dir / image.dockerfile_name()
         dockerfile_path.parent.mkdir(parents=True, exist_ok=True)
+        dockerfile_content = image.dockerfile()
+        # For PR-specific images, append a final layer that scopes the cloned 
+        # repo to pr.base.sha's ancestor chain.
+        if isinstance(image.dependency(), Image):
+            dockerfile_content += _strip_future_history_run(
+                f"/home/{image.pr.repo}", image.pr.base.sha
+            )
         with open(dockerfile_path, "w", encoding="utf-8", newline="\n") as f:
-            f.write(image.dockerfile())
+            f.write(dockerfile_content)
 
         for file in image.files():
             file_path = image_dir / file.dir / file.name


### PR DESCRIPTION
# Summary

Multi-SWEBench Dockerfiles still contain the future git history in the repo, agents being evaluated often find this and exploit it to skip solving the actual problem. 

This was mentioned in https://github.com/multi-swe-bench/multi-swe-bench/issues/70 but hasn't been addressed yet, so I took a pass at cleaning it up so we could more accurately compare models that we've been training. 

## Steps to reproduce 

Full steps to reproduce with a fix in the published images: 

<details><summary>Repro Steps</summary>
<p>

1. Pull a published image

```
docker pull mswebench/mui_m_material-ui:pr-23487
```

2. Use docker interactive with network off (just to show it's all locally available) 

```
docker run --rm -it --network none --entrypoint bash mswebench/mui_m_material-ui:pr-23487
```

3. Showcase current commit and how far ahead head is

```
cd /home/material-ui
git rev-parse HEAD

# Showcases what is available
git for-each-ref refs/remotes/ | wc -l 
git for-each-ref refs/tags/ | wc -l


# Gets the actual fix and contents
git log --all --oneline --grep='#23487' | head
git show 865fa5a04a | head -60
```

These yield: 

```
5115f08e29babb11481a190d68e7fd045f3ce804

32

536

865fa5a04a [Autocomplete] Add ability to override key down events handlers (#23487)

commit 865fa5a04ae8e2c0079b28ad84c7451924f597de
Author: hessaam <50245527+hessaam@users.noreply.github.com>
Date:   Mon Nov 30 20:30:22 2020 +0330

    [Autocomplete] Add ability to override key down events handlers (#23487)

diff --git a/docs/src/pages/components/autocomplete/autocomplete.md b/docs/src/pages/components/autocomplete/autocomplete.md
index 12871bd818..358e538826 100644
--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -274,6 +274,22 @@ Search within 10,000 randomly generated options. The list is virtualized thanks
 
 {{"demo": "pages/components/autocomplete/Virtualize.js"}}
 
+## Events
+
+If you would like to prevent the default key handler behavior, you can set the event's `defaultMuiPrevented` property to `true`:
+
+```jsx
+<Autocomplete
+  onKeyDown={(event) => {
+    if (event.key === 'Enter') {
+      // Prevent's default 'Enter' behavior.
+      event.defaultMuiPrevented = false;
+      // your handler code
+    }
+  }}
+/>
+```
+
 ## Limitations
 
 ### autocomplete/autofill
diff --git a/packages/material-ui/src/Autocomplete/Autocomplete.test.js b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
index a98db73e74..83fde66828 100644
--- a/packages/material-ui/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui/src/Autocomplete/Autocomplete.test.js
@@ -2120,4 +2120,37 @@ describe('<Autocomplete />', () => {
 
     expect(getAllByRole('option')).to.have.length(1);
   });
+
+  it('should prevent the default event handlers', () => {
+    const handleChange = spy();
+    const handleSubmit = spy();
+    const Test = () => (
+      <div
+        onKeyDown={(event) => {
+          if (!event.defaultPrevented && event.key === 'Enter') {
+            handleSubmit();
+          }
+        }}
+      >
+        <Autocomplete
+          options={['one', 'two']}
+          onChange={handleChange}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.persist();
+              event.defaultMuiPrevented = true;

```

This applies for all images, agents often find this kind of info when exploring git history. 


</p>
</details> 

## Changes 

This PR focused on making the fewest changes possible, but it could also be accomplished by updating each individual class definition that is used to build dockerfiles. 

The core change is:

```
RUN set -e && \
    git remote remove origin 2>/dev/null || true && \
    git for-each-ref --format='delete %(refname)' refs/heads refs/remotes refs/tags | git update-ref --stdin && \
    rm -f .git/FETCH_HEAD .git/ORIG_HEAD && \
    git reflog expire --expire=now --all && \
    git gc --prune=now
```

Which will: 
1. Drop `[remote "origin"]` so the upstream URL is gone.
2. Delete every ref under `refs/heads`, `refs/remotes`, `refs/tags` so only `HEAD` remains.
   - Note: Tags is less commonly exploited, but why leave it if we're already taking care of this
3. Remove `.git/FETCH_HEAD` and `.git/ORIG_HEAD` so leftover SHAs/branch-name metadata are gone.
   - In testing models would sometimes find these and get confused, just eliminates needless churn
4. Expire all reflogs so reflog-pinned objects can be pruned.
5. `gc --prune=now` actually removes the now-unreachable commit/tree/blob objects from the pack.

## Testing

Ran locally and confirmed on numerous images across languages (although some failed due to unrelated issues with building from scratch, like missing external dependencies). With the fix none of these had the future commits.

