### PR TITLE
Fix skip and crash/timeout handling in Go and C++ test-log parsers

### DIFF
--- a/multi_swe_bench/harness/repos/cpp/nlohmann/json_4517_to_1257.py
+++ b/multi_swe_bench/harness/repos/cpp/nlohmann/json_4517_to_1257.py
@@ -213,7 +213,7 @@ class JSON_4517_TO_1257(Instance):
         import re
 
         # Pattern for passed tests
-        passed_pattern = re.compile(r"Test #\d+: (.*?)\s+\.+\s+Passed")
+        passed_pattern = re.compile(r"Test\s+#\d+: (.*?)\s+\.+\s+Passed")
         # Pattern for failed tests due to build errors
         failed_pattern = re.compile(r"make\[\d+\]: \*\*\* .*?/(test-.*?)\.dir")
         for line in log.splitlines():

--- a/multi_swe_bench/harness/repos/cpp/simdjson/simdjson_1674_to_1534.py
+++ b/multi_swe_bench/harness/repos/cpp/simdjson/simdjson_1674_to_1534.py
@@ -194,7 +194,7 @@ class SIMDJSON_1674_TO_1534(Instance):
         import re
         import json
 
-        passed_pattern = re.compile(r"Test #\d+: (.*) \.+   Passed")
+        passed_pattern = re.compile(r"Test\s+#\d+: (.*) \.+   Passed")
         failed_pattern = re.compile(r"\t \d+ - (.*) \(Failed\)")
         for line in log.splitlines():
             passed_match = passed_pattern.search(line)

--- a/multi_swe_bench/harness/repos/golang/beego/beego.py
+++ b/multi_swe_bench/harness/repos/golang/beego/beego.py
@@ -226,7 +226,6 @@ class Beego(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Beego(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/caddyserver/caddy.py
+++ b/multi_swe_bench/harness/repos/golang/caddyserver/caddy.py
@@ -226,7 +226,6 @@ class Caddy(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Caddy(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/cli/cli.py
+++ b/multi_swe_bench/harness/repos/golang/cli/cli.py
@@ -226,7 +226,6 @@ class Cli(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Cli(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/concourse/concourse.py
+++ b/multi_swe_bench/harness/repos/golang/concourse/concourse.py
@@ -276,7 +276,6 @@ class concourse(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -312,7 +311,7 @@ class concourse(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/etcd_io/etcd.py
+++ b/multi_swe_bench/harness/repos/golang/etcd_io/etcd.py
@@ -258,7 +258,6 @@ class Etcd(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -297,7 +296,7 @@ class Etcd(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/fatedier/frp.py
+++ b/multi_swe_bench/harness/repos/golang/fatedier/frp.py
@@ -226,7 +226,6 @@ class Frp(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Frp(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/gin_gonic/gin.py
+++ b/multi_swe_bench/harness/repos/golang/gin_gonic/gin.py
@@ -226,7 +226,6 @@ class Gin(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -265,7 +264,7 @@ class Gin(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/go_gorm/gorm.py
+++ b/multi_swe_bench/harness/repos/golang/go_gorm/gorm.py
@@ -226,7 +226,6 @@ class Gorm(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -265,7 +264,7 @@ class Gorm(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/gohugoio/hugo.py
+++ b/multi_swe_bench/harness/repos/golang/gohugoio/hugo.py
@@ -226,7 +226,6 @@ class Hugo(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Hugo(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/grpc/grpc_go.py
+++ b/multi_swe_bench/harness/repos/golang/grpc/grpc_go.py
@@ -226,7 +226,6 @@ class GrpcGo(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -265,7 +264,7 @@ class GrpcGo(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/istio/istio.py
+++ b/multi_swe_bench/harness/repos/golang/istio/istio.py
@@ -226,7 +226,6 @@ class Istio(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Istio(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/jesseduffield/lazygit.py
+++ b/multi_swe_bench/harness/repos/golang/jesseduffield/lazygit.py
@@ -226,7 +226,6 @@ class Lazygit(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Lazygit(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/junegunn/fzf.py
+++ b/multi_swe_bench/harness/repos/golang/junegunn/fzf.py
@@ -226,7 +226,6 @@ class Fzf(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Fzf(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/labstack/echo.py
+++ b/multi_swe_bench/harness/repos/golang/labstack/echo.py
@@ -226,7 +226,6 @@ class Echo(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Echo(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/natsio/natsserver.py
+++ b/multi_swe_bench/harness/repos/golang/natsio/natsserver.py
@@ -226,7 +226,6 @@ class natsserver(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class natsserver(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/nektos/act.py
+++ b/multi_swe_bench/harness/repos/golang/nektos/act.py
@@ -226,7 +226,6 @@ class Act(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Act(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/prometheus/prometheus.py
+++ b/multi_swe_bench/harness/repos/golang/prometheus/prometheus.py
@@ -226,7 +226,6 @@ class Prometheus(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Prometheus(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/syncthing/syncthing.py
+++ b/multi_swe_bench/harness/repos/golang/syncthing/syncthing.py
@@ -226,7 +226,6 @@ class Syncthing(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -262,7 +261,7 @@ class Syncthing(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 

--- a/multi_swe_bench/harness/repos/golang/zeromicro/go_zero.py
+++ b/multi_swe_bench/harness/repos/golang/zeromicro/go_zero.py
@@ -226,7 +226,6 @@ class GoZero(Instance):
         re_pass_tests = [re.compile(r"--- PASS: (\S+)")]
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
         re_skip_tests = [re.compile(r"--- SKIP: (\S+)")]
 
@@ -265,7 +264,7 @@ class GoZero(Instance):
                     test_name = skip_match.group(1)
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
 


### PR DESCRIPTION
## Summary

Following up on the email thread about parser-level issues in the test-log parsers, this PR proposes fixes for the three highest-confidence, real-data-validated items. All changes are surgical edits to the existing `parse_log` functions.

- **Go (19 files): skip handling was inverted.** The skip branch recorded a skip only when the test was already in `failed_tests`, so an ordinary skipped test (never failed) was silently dropped.
- **Go (19 files): an over-broad fallback regex mislabeled package paths as failed tests.** The fallback `re.compile(r"FAIL:?\s?(.+?)\s")` matches the `go test` package summary line (`FAIL<TAB><import-path><TAB><time>`) and records the import path as a "failed test".
- **C++ (2 files): the `ctest` pass pattern dropped single-digit-numbered tests.** `ctest` right-aligns the test number, so single-digit tests print as `Test  #1` (two spaces). The single-space `Test #\d+` pattern matched `#10`+ but not `#1`–`#9`.

These are parser-level correctness fixes. They make the per-test PASS/FAIL/SKIP buckets faithful to the runner output. On a small real Docker re-run they did **not** change `resolved` verdicts, because the same parser builds the gold sets and scores the candidate, so the effect is on measurement fidelity and data quality rather than on leaderboard numbers. Full analysis: https://doi.org/10.5281/zenodo.20690733

## Changes

### 1. Go: record ordinary skips (`repos/golang/*`)

```diff
                     if test_name in passed_tests:
                         continue
-                    if test_name not in failed_tests:
+                    if test_name in failed_tests:
                         continue
                     skipped_tests.add(get_base_name(test_name))
```

A `--- SKIP:` test that was not previously failed is now recorded as skipped (mirroring the `passed`/`failed` branches, which already guard on `in`).

Reproduce:
```
--- SKIP: TestWindowsOnly (0.00s)
```
Before: `skipped_tests = {}`. After: `skipped_tests = {"TestWindowsOnly"}`.
On a real `cli` run, 5 genuine `--- SKIP:` tests are emitted (Windows-gated tests skipped on Linux): captured 0/5 before, 5/5 after.

### 2. Go: drop the over-broad FAIL fallback (`repos/golang/*`)

```diff
         re_fail_tests = [
             re.compile(r"--- FAIL: (\S+)"),
-            re.compile(r"FAIL:?\s?(.+?)\s"),
         ]
```

Reproduce:
```
--- FAIL: TestFoo (0.01s)
FAIL
FAIL	github.com/org/proj/pkg/cmd	0.123s
```
Before: `failed_tests = {"TestFoo", "github.com/org/proj/pkg/cmd"}` (the summary line's import path is captured). After: `failed_tests = {"TestFoo"}`.
Across the full Go eval set (428 instances), ~45% of the entries in the raw `test_patch_result.failed_tests` were package paths rather than tests. (If this fallback was intended for a specific runner format, I am happy to narrow it instead of removing it.)

### 3. C++: allow variable whitespace in the ctest pattern (`repos/cpp/*`)

```diff
-        passed_pattern = re.compile(r"Test #\d+: (.*?)\s+\.+\s+Passed")
+        passed_pattern = re.compile(r"Test\s+#\d+: (.*?)\s+\.+\s+Passed")
```

Reproduce (a clean, fully-passing ctest run):
```
      1/80 Test  #1: test_a ...........   Passed    0.01 sec
     10/80 Test #10: test_j ...........   Passed    0.01 sec
```
Before: `Test #\d+` matches `#10` but not `Test  #1` (two spaces), so tests `#1`–`#9` are dropped. After: both match.
On a real `nlohmann/json` run (80/80 passing): captured 71/80 before, 80/80 after.

## Scope and follow-ups

This PR is intentionally limited to the three real-data-validated fixes so they can be reproduced cleanly. Not included here (happy to follow up if useful):

- Skip handling is also dropped by parsers in C, JavaScript, TypeScript, Python (pytest), and Java; those were measured on synthetic logs and would benefit from your evaluation to confirm before changing.
- A parser-consistency CI check (the same synthetic log should yield the same buckets across all of a repo's version-pinned parsers).
- A canonical test-name normalization pass for set compatibility across version tags.

I would welcome your review and corrections, and I am glad to adjust any of the above for your evaluation configuration.

---

*Disclosure: I used an AI assistant (Claude) for parts of the analysis and to help draft the reproduction examples in this PR. All code changes were reviewed and verified against real `go test` and `ctest` output before submitting.*
